### PR TITLE
Fix header guard typo

### DIFF
--- a/include/character_classes.h
+++ b/include/character_classes.h
@@ -1,6 +1,6 @@
 // character_classes.h
 
-#ifndef SRX_CHARCATER_CLASSES_H
+#ifndef SRX_CHARACTER_CLASSES_H
 #define SRX_CHARACTER_CLASSES_H
 
 // Handle character class ranges


### PR DESCRIPTION
## Summary
- fix a typo in `character_classes.h` header guard

## Testing
- `make test` *(fails: Makefile:76: *** missing separator)*

------
https://chatgpt.com/codex/tasks/task_e_683f4b0bea288328bfb1501b5f977016