### PR TITLE
Fix start pointer in char_in_class

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -39,6 +39,7 @@ bool is_whitespace(char c) { return isspace(c); }
 
 // Check if a character is in a character class
 bool char_in_class(char c, const char *regex, int *class_len) {
+  const char *start = regex;
   bool negate = false;
   bool match = false;
 


### PR DESCRIPTION
## Summary
- use a local `start` pointer in `char_in_class`

## Testing
- `make test` *(fails: missing separator in Makefile)*

------
https://chatgpt.com/codex/tasks/task_e_683f4b08a704832892b739c36fc5621f