### PR TITLE
Move create_state into implementation file

### DIFF
--- a/include/srxe.h
+++ b/include/srxe.h
@@ -42,14 +42,6 @@ typedef struct FSM {
   State *start;
 } FSM;
 
-State *create_state(StateType type, char match_char) {
-  State *state = (State *)malloc(sizeof(State));
-  state->type = type;
-  state->match_char = match_char;
-  state->out_count = 0;
-  state->out_capacity = INITIAL_TRANSITIONS;
-  state->out = (State **)malloc(INITIAL_TRANSITIONS * sizeof(State *));
-  return state;
-}
+State *create_state(StateType type, char match_char);
 
 #endif // SRX_SRXE_H

--- a/src/srxe.c
+++ b/src/srxe.c
@@ -1,5 +1,17 @@
 // srxe.c
 
+#include "srxe.h"
+
+State *create_state(StateType type, char match_char) {
+  State *state = (State *)malloc(sizeof(State));
+  state->type = type;
+  state->match_char = match_char;
+  state->out_count = 0;
+  state->out_capacity = INITIAL_TRANSITIONS;
+  state->out = (State **)malloc(INITIAL_TRANSITIONS * sizeof(State *));
+  return state;
+}
+
 void add_transition(State *from, State *to) {
   if (from->out_count >= from->out_capacity) {
     from->out_capacity *= 2;


### PR DESCRIPTION
## Summary
- shift `create_state` implementation out of header
- add `create_state` to `src/srxe.c` and include `srxe.h`

## Testing
- `make` *(fails: missing separator in Makefile)*

------
https://chatgpt.com/codex/tasks/task_e_683f4b0775948328a4041cfb772c4313