### PR TITLE
Fix isascii function semicolon

### DIFF
--- a/src/posix.c
+++ b/src/posix.c
@@ -2,7 +2,7 @@
 
 #include "posix.h"
 
-bool isascii(unsigned char c) { return c < 128 }
+bool isascii(unsigned char c) { return c < 128; }
 
 bool isblank(unsigned char c) { return c == ' ' || c == '\t'; }
 


### PR DESCRIPTION
## Summary
- fix missing semicolon in `isascii`

## Testing
- `make test` *(fails: Makefile missing separator)*

------
https://chatgpt.com/codex/tasks/task_e_683f4b090b2c8328b487d92869fcb56a