### PR TITLE
Add stub Unicode script helpers

### DIFF
--- a/include/unicode.h
+++ b/include/unicode.h
@@ -16,4 +16,8 @@ bool match_word_boundary(const char *text, bool word_boundary);
 bool match_unicode_casefold(const char *regex, const char *text,
                             bool case_insensitive);
 
+// Simple helpers for Unicode scripts
+bool is_greek_script(char c);
+bool is_cyrillic_script(char c);
+
 #endif // SRX_UNICODE_H

--- a/src/unicode.c
+++ b/src/unicode.c
@@ -2,6 +2,17 @@
 
 #include "unicode.h"
 
+// Placeholder implementations for script checks
+bool is_greek_script(char c) {
+  (void)c;
+  return false;
+}
+
+bool is_cyrillic_script(char c) {
+  (void)c;
+  return false;
+}
+
 bool match_unicode_script(const char *script_name, char c, bool negate) {
   if (strcmp(script_name, "Greek") == 0) {
     return negate ? !is_greek_script(c)


### PR DESCRIPTION
## Summary
- add declarations for Unicode script helpers in header
- implement placeholder helpers in `src/unicode.c`

## Testing
- `make test` *(fails: Makefile missing separator)*

------
https://chatgpt.com/codex/tasks/task_e_683f4b067c4483289cd484dfff54d649