### PR TITLE
Resolve duplicate functions

### DIFF
--- a/include/unicode.h
+++ b/include/unicode.h
@@ -3,8 +3,6 @@
 #ifndef SRX_UNICODE_H
 #define SRX_UNICODE_H
 
-// Handle Unicode Script Support (\p{Script} and \P{Script})
-bool match_unicode_script(char script, char c, bool negate);
 
 // Check if a character matches a Unicode property (like \p{L})
 bool match_unicode_property(char property, char c, bool negate);

--- a/src/engine.c
+++ b/src/engine.c
@@ -108,10 +108,10 @@ bool match_here(const char *regex, const char *text, bool case_insensitive,
                       multi_line);
   }
 
-  // Handle Unicode script support
+  // Handle Unicode property support
   if (*regex == '\\' && (*(regex + 1) == 'p' || *(regex + 1) == 'P')) {
     bool negate = (*(regex + 1) == 'P');
-    return match_unicode_script(*(regex + 3), *text, negate) &&
+    return match_unicode_property(*(regex + 3), *text, negate) &&
            match_here(regex + 5, text + 1, case_insensitive, dot_all,
                       multi_line);
   }
@@ -161,8 +161,8 @@ bool match_here(const char *regex, const char *text, bool case_insensitive,
 
   // Handle non-greedy {min,} quantifiers
   if (*regex == '{') {
-    int min;
-    parse_braces(regex, &min);
+    int min, max;
+    parse_braces(regex, &min, &max);
     return match_range_infinite(*(regex - 1), regex + 1, text, min,
                                 case_insensitive, dot_all, multi_line);
   }

--- a/src/srxe.c
+++ b/src/srxe.c
@@ -9,56 +9,7 @@ void add_transition(State *from, State *to) {
   from->out[from->out_count++] = to;
 }
 
-bool char_in_class(char c, const char *regex, int *class_len) {
-  const char *start = regex;
-  bool negate = false;
-  bool match = false;
 
-  if (*regex == '^') {
-    negate = true;
-    regex++;
-  }
-
-  while (*regex != ']' && *regex != '\0') {
-    if (*(regex + 1) == '-' && *(regex + 2) != ']') {
-      if (c >= *regex && c <= *(regex + 2)) {
-        match = true;
-      }
-      regex += 3;
-    } else {
-      if (c == *regex) {
-        match = true;
-      }
-      regex++;
-    }
-  }
-
-  *class_len = (regex - start) + 1;
-  return negate ? !match : match;
-}
-
-bool match_unicode_property(char property, char c, bool negate) {
-  bool result = false;
-  switch (property) {
-  case 'L':
-    result = iswalpha(c);
-    break; // Letters
-  case 'N':
-    result = iswdigit(c);
-    break; // Numbers
-  case 'P':
-    result = ispunct(c);
-    break; // Punctuation
-  case 'S':
-    result = isspace(c);
-    break; // Whitespace
-  }
-  return negate ? !result : result;
-}
-
-bool match_unicode_casefold(const char *regex, const char *text, bool case_insensitive) {
-  return case_insensitive ? tolower(*regex) == tolower(*text) : *regex == *text;
-}
 
 FSM *compile(const char *regex) {
   FSM *fsm = (FSM *)malloc(sizeof(FSM));

--- a/src/unicode.c
+++ b/src/unicode.c
@@ -2,19 +2,6 @@
 
 #include "unicode.h"
 
-bool match_unicode_script(const char *script_name, char c, bool negate) {
-  if (strcmp(script_name, "Greek") == 0) {
-    return negate ? !is_greek_script(c)
-                  : is_greek_script(c); // Custom function for Greek script
-  }
-  if (strcmp(script_name, "Cyrillic") == 0) {
-    return negate
-               ? !is_cyrillic_script(c)
-               : is_cyrillic_script(c); // Custom function for Cyrillic script
-  }
-  // Add more scripts as needed...
-  return false;
-}
 
 bool match_unicode_property(char property, char c, bool negate) {
   switch (property) {

--- a/src/utils.c
+++ b/src/utils.c
@@ -39,6 +39,7 @@ bool is_whitespace(char c) { return isspace(c); }
 
 // Check if a character is in a character class
 bool char_in_class(char c, const char *regex, int *class_len) {
+  const char *start = regex;
   bool negate = false;
   bool match = false;
 


### PR DESCRIPTION
## Summary
- consolidate char class handling into utils
- remove duplicate unicode helpers
- update engine to use shared helpers
- parse both min and max for '{min,}' quantifiers

## Testing
- `make` *(fails: missing separator)*

------
https://chatgpt.com/codex/tasks/task_e_683f4b09e6cc83288941afd50e2e29e5