### PR TITLE
Fix utils header guard comment

### DIFF
--- a/include/utils.h
+++ b/include/utils.h
@@ -21,4 +21,4 @@ bool char_equals(char c1, char c2, bool case_insensitive);
 // Parse the {min,max} quantifier
 void parse_braces(const char *regex, int *min, int *max);
 
-#endif // UTILS_H
+#endif // SRX_UTILS_H


### PR DESCRIPTION
## Summary
- update closing comment in utils header

## Testing
- `make` *(fails: Makefile missing separator)*

------
https://chatgpt.com/codex/tasks/task_e_684201515b3c8328b9f305c3b91bb8ed