### PR TITLE
Add forward struct declarations to srxe.h

### DIFF
--- a/include/srxe.h
+++ b/include/srxe.h
@@ -5,6 +5,9 @@
 
 #define INITIAL_TRANSITIONS 4
 
+typedef struct State State;
+typedef struct FSM FSM;
+
 void add_transition(State *from, State *to);
 bool char_in_class(char c, const char *regex, int *class_len);
 bool match_unicode_property(char property, char c, bool negate);
@@ -30,17 +33,17 @@ typedef enum {
   ASSERT_WORD_BOUNDARY // Word boundary \b or \B
 } StateType;
 
-typedef struct State {
+struct State {
   StateType type;
   char match_char;    // Character to match in CHAR or CHAR_CLASS
   struct State **out; // Dynamically allocated array of outgoing transitions
   int out_count;      // Current number of transitions
   int out_capacity;   // Current capacity of the outgoing transitions
-} State;
+};
 
-typedef struct FSM {
+struct FSM {
   State *start;
-} FSM;
+};
 
 State *create_state(StateType type, char match_char);
 


### PR DESCRIPTION
## Summary
- add forward declarations for `State` and `FSM`
- convert struct definitions to named structs for clarity

## Testing
- `make check` *(fails: Makefile:76: *** missing separator)*

------
https://chatgpt.com/codex/tasks/task_e_6842014ec58c83288dd2f91d566f1eaa