### PR TITLE
Remove duplicate lookbehind function

### DIFF
--- a/include/lookaround.h
+++ b/include/lookaround.h
@@ -3,10 +3,6 @@
 #ifndef SRX_LOOKAROUND_H
 #define SRX_LOOKAROUND_H
 
-// Handle fixed-length lookbehind assertions ((?<=...) or (?<!...))
-bool match_lookbehind(const char *regex, const char *text, bool positive,
-                      bool case_insensitive);
-
 // Handle lookahead assertions ((?=...), (?!...))
 bool match_lookahead(const char *regex, const char *text, bool positive,
                      bool case_insensitive, bool dot_all, bool multi_line);

--- a/src/engine.c
+++ b/src/engine.c
@@ -139,7 +139,8 @@ bool match_here(const char *regex, const char *text, bool case_insensitive,
   // Fixed-length lookbehind assertions ((?<=...) and (?<!...))
   if (*regex == '(' && *(regex + 1) == '?' && (*(regex + 2) == '<')) {
     bool positive = (*(regex + 3) == '=');
-    return match_lookbehind(regex + 4, text, positive, case_insensitive) &&
+    return match_lookbehind(regex + 4, text, positive, case_insensitive,
+                            dot_all, multi_line, 3) &&
            match_here(regex + 4, text, case_insensitive, dot_all, multi_line);
   }
 

--- a/src/lookaround.c
+++ b/src/lookaround.c
@@ -2,21 +2,6 @@
 
 #include "lookaround.h"
 
-// Handle variable-length lookbehind assertions ((?<=...) or (?<!...))
-bool match_lookbehind(const char *regex, const char *text, bool positive,
-                      bool case_insensitive, bool dot_all, bool multi_line) {
-  const char *start = text;
-  // We will attempt to match from the start of the string to the current text
-  // position
-  while (start <= text) {
-    if (match_here(regex, start, case_insensitive, dot_all, multi_line)) {
-      return positive; // Return true if positive lookbehind, false otherwise
-    }
-    start++;
-  }
-  return !positive; // Return false if positive lookbehind, true otherwise
-}
-
 // Handle lookahead assertions ((?=...), (?!...))
 bool match_lookahead(const char *regex, const char *text, bool positive,
                      bool case_insensitive, bool dot_all, bool multi_line) {


### PR DESCRIPTION
## Summary
- drop the duplicate `match_lookbehind` prototype
- remove the extra `match_lookbehind` implementation
- update `engine.c` to use the unified `match_lookbehind` signature

## Testing
- `make test` *(fails: Makefile:76: *** missing separator.  Stop.)*

------
https://chatgpt.com/codex/tasks/task_e_6842018379608328a27960f605981088