### PR TITLE
Fix compilation issues and refine quantifier handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ BINARY ?= srxe
 TARGET := $(BINDIR)/$(BINARY)
 
 # Source files
-SRCS := $(shell find $(SRCDIR) -name "*.c")
+SRCS := $(filter-out $(SRCDIR)/srxe.c $(SRCDIR)/main.c, $(shell find $(SRCDIR) -name "*.c"))
 OBJS := $(SRCS:$(SRCDIR)/%.c=$(BUILDDIR_MAIN)/%.o)
 TEST_SRCS := $(shell find $(TESTDIR) -name "*.c")
 TEST_OBJS := $(TEST_SRCS:$(TESTDIR)/%.c=$(BUILDDIR_TEST)/%.o)

--- a/include/engine.h
+++ b/include/engine.h
@@ -7,8 +7,8 @@
 
 #define MAX_GROUPS 256
 
-char captured_groups[MAX_GROUPS][256];
-int group_lengths[MAX_GROUPS];
+extern char captured_groups[MAX_GROUPS][256];
+extern int group_lengths[MAX_GROUPS];
 
 bool match_here(const char *regex, const char *text, bool case_insensitive,
                 bool dot_all, bool multi_line);

--- a/include/lookaround.h
+++ b/include/lookaround.h
@@ -6,11 +6,6 @@
 
 #include <stdbool.h>
 
-// Handle fixed-length lookbehind assertions ((?<=...) or (?<!...))
-bool match_lookbehind(const char *regex, const char *text, bool positive,
-                      bool case_insensitive);
-
-
 // Handle lookahead assertions ((?=...), (?!...))
 bool match_lookahead(const char *regex, const char *text, bool positive,
                      bool case_insensitive, bool dot_all, bool multi_line);

--- a/src/groups.c
+++ b/src/groups.c
@@ -43,21 +43,14 @@ bool match_atomic_group(const char *regex, const char *text,
   return true;
 }
 
-// Structure to store captured groups
-typedef struct {
-  char *captured_text[MAX_GROUPS];
-  int group_lengths[MAX_GROUPS];
-} group_capture;
-
 // Subroutine Calls ((?1), (?&name))
 bool match_subroutine(const char *regex, const char *text,
                       bool case_insensitive, bool dot_all, bool multi_line,
-                      int group_num, group_capture *captures) {
-  // Match the previous captured group (group_num)
+                      int group_num) {
   if (group_num > 0 && group_num < MAX_GROUPS) {
-    if (strncmp(text, captures->captured_text[group_num],
-                captures->group_lengths[group_num]) == 0) {
-      return match_here(regex, text + captures->group_lengths[group_num],
+    if (strncmp(text, captured_groups[group_num],
+                group_lengths[group_num]) == 0) {
+      return match_here(regex, text + group_lengths[group_num],
                         case_insensitive, dot_all, multi_line);
     }
   }

--- a/src/lookaround.c
+++ b/src/lookaround.c
@@ -2,6 +2,7 @@
 
 #include "lookaround.h"
 #include <stdbool.h>
+#include <stddef.h>
 #include "engine.h"
 
 // Handle lookahead assertions ((?=...), (?!...))
@@ -16,13 +17,10 @@ bool match_lookahead(const char *regex, const char *text, bool positive,
 bool match_lookbehind(const char *regex, const char *text, bool positive,
                       bool case_insensitive, bool dot_all, bool multi_line,
                       int lookbehind_length) {
-  const char *lookbehind_start =
-      (text >= lookbehind_length) ? text - lookbehind_length : NULL;
-
-  if (lookbehind_start && match_here(regex, lookbehind_start, case_insensitive,
-                                     dot_all, multi_line)) {
+  const char *lookbehind_start = text - lookbehind_length;
+  if (match_here(regex, lookbehind_start, case_insensitive, dot_all,
+                 multi_line)) {
     return positive ? true : false;
   }
-
-  return !positive; // Return false for positive lookbehind if no match
+  return !positive;
 }

--- a/src/quantifiers.c
+++ b/src/quantifiers.c
@@ -1,141 +1,132 @@
 #include "quantifiers.h"
+#include "engine.h"
+#include "utils.h"
 
-// Function to handle group matching with alternation support
-bool match_group(const char *regex, const char *text, bool case_insensitive) {
-  const char *group_start = regex;
-  const char *group_end = regex;
-  int parentheses_count = 0;
-
-  // Find the matching closing parenthesis and handle nested groups
-  while (*group_end != '\0') {
-    if (*group_end == '(') {
-      parentheses_count++;
-    } else if (*group_end == ')') {
-      parentheses_count--;
-      if (parentheses_count == 0) {
-        break;
-      }
-    }
-    group_end++;
+// Helper to check if character c matches t with options
+static bool matches(char c, char t, bool case_insensitive, bool dot_all) {
+  if (c == '.') {
+    return dot_all || t != '\n';
   }
-
-  // Handle alternation within the group
-  return match_alternation(group_start, group_end, text, case_insensitive);
-}
-
-// Function to handle alternation within groups (e.g., a|b|c)
-bool match_alternation(const char *start, const char *end, const char *text,
-                       bool case_insensitive) {
-  const char *alt_start = start;
-  const char *alt_end = start;
-
-  while (alt_end <= end && *alt_end != '\0') {
-    // Look for alternation symbol '|'
-    if (*alt_end == '|') {
-      // Try matching the current alternation pattern
-      if (match_here(alt_start, text, case_insensitive, false, false)) {
-        return true;
-      }
-      alt_start = alt_end + 1; // Move to the next alternative
-    }
-    alt_end++;
-  }
-
-  // Try the last pattern after the last '|'
-  return match_here(alt_start, text, case_insensitive, false, false);
-}
-
-// Extended function to match more complex patterns (e.g., character classes,
-// groups)
-bool match_pattern(const char *pattern, const char *text,
-                   bool case_insensitive) {
-  if (*pattern == '[') {
-    // Handle character classes [a-z], [^a-z], etc.
-    return match_char_class(pattern, *text, case_insensitive);
-  } else if (*pattern == '(') {
-    // Handle groups (abc), (a|b|c), etc.
-    return match_group(pattern, text, case_insensitive);
-  } else {
-    // Default to single character match
-    return char_equals(*text, *pattern, case_insensitive);
-  }
-}
-
-// Generalized function to handle greedy (*) and lazy (*?) quantifiers
-bool match_star_general(const char *pattern, const char *regex,
-                        const char *text, bool case_insensitive, bool dot_all,
-                        bool multi_line, bool lazy) {
-  do {
-    if (match_here(regex, text, case_insensitive, dot_all, multi_line)) {
-      return true;
-    }
-    if (lazy) {
-      break; // Lazy match, stop as soon as there's a match
-    }
-  } while (*text != '\0' && match_pattern(pattern, text++, case_insensitive));
-  return false;
+  return char_equals(c, t, case_insensitive);
 }
 
 // Greedy (*) quantifier
-bool match_star(const char *pattern, const char *regex, const char *text,
+bool match_star(char c, const char *regex, const char *text,
                 bool case_insensitive, bool dot_all, bool multi_line) {
-  return match_star_general(pattern, regex, text, case_insensitive, dot_all,
-                            multi_line, false);
-}
-
-// Lazy (*?) quantifier
-bool match_star_lazy(const char *pattern, const char *regex, const char *text,
-                     bool case_insensitive, bool dot_all, bool multi_line) {
-  return match_star_general(pattern, regex, text, case_insensitive, dot_all,
-                            multi_line, true);
-}
-
-// Possessive (*+) quantifier (no backtracking)
-bool match_star_possessive(const char *pattern, const char *regex,
-                           const char *text, bool case_insensitive,
-                           bool dot_all, bool multi_line) {
-  while (*text != '\0' && match_pattern(pattern, text++, case_insensitive)) {
-    // Match as many as possible, but no backtracking
+  const char *t = text;
+  while (*t != '\0' && matches(c, *t, case_insensitive, dot_all)) {
+    t++;
   }
-  return match_here(regex, text, case_insensitive, dot_all,
-                    multi_line); // No backtracking
-}
-
-// Optimized lazy range quantifier (e.g., +?, {min,max}?)
-bool match_lazy_range(const char *pattern, const char *regex, const char *text,
-                      int min, int max, bool case_insensitive, bool dot_all,
-                      bool multi_line) {
-  int count = 0;
-  while (count < max && *text != '\0' &&
-         match_pattern(pattern, text, case_insensitive)) {
-    text++;
-    count++;
-    if (count >= min &&
-        match_here(regex, text, case_insensitive, dot_all, multi_line)) {
-      return true; // Stop early for lazy match
+  do {
+    if (match_here(regex, t, case_insensitive, dot_all, multi_line)) {
+      return true;
     }
-  }
+  } while (t-- > text);
   return false;
 }
 
-// Optimized greedy range quantifier (e.g., {min,max})
-bool match_range(const char *pattern, const char *regex, const char *text,
-                 int min, int max, bool case_insensitive, bool dot_all,
-                 bool multi_line) {
-  int count = 0;
-  while (count < max && *text != '\0' &&
-         match_pattern(pattern, text++, case_insensitive)) {
-    count++;
+// Lazy (*?) quantifier
+bool match_star_lazy(char c, const char *regex, const char *text,
+                     bool case_insensitive, bool dot_all, bool multi_line) {
+  const char *t = text;
+  while (1) {
+    if (match_here(regex, t, case_insensitive, dot_all, multi_line)) {
+      return true;
+    }
+    if (*t == '\0' || !matches(c, *t, case_insensitive, dot_all)) {
+      return false;
+    }
+    t++;
   }
-  return count >= min &&
-         match_here(regex, text, case_insensitive, dot_all, multi_line);
 }
 
-// Error handling for invalid quantifier usage (min > max)
-bool validate_range(int min, int max) {
-  if (min > max || min < 0 || max < 0) {
-    fprintf(stderr, "Error: Invalid quantifier range {%d,%d}\n", min, max);
+// Possessive (*+) quantifier (no backtracking)
+bool match_star_possessive(char c, const char *regex, const char *text,
+                           bool case_insensitive, bool dot_all,
+                           bool multi_line) {
+  const char *t = text;
+  while (*t != '\0' && matches(c, *t, case_insensitive, dot_all)) {
+    t++;
+  }
+  if (*regex == '\0') {
+    return *t == '\0';
+  }
+  return match_here(regex, t, case_insensitive, dot_all, multi_line);
+}
+
+// Lazy range quantifier (e.g., +?, {min,max}?)
+bool match_lazy_range(char c, const char *regex, const char *text, int min,
+                      int max, bool case_insensitive, bool dot_all,
+                      bool multi_line) {
+  const char *t = text;
+  int count = 0;
+
+  while (count < min) {
+    if (*t == '\0' || !matches(c, *t, case_insensitive, dot_all)) {
+      return false;
+    }
+    t++;
+    count++;
+  }
+
+  while (count <= max) {
+    if (match_here(regex, t, case_insensitive, dot_all, multi_line)) {
+      return true;
+    }
+    if (count == max || *t == '\0' || !matches(c, *t, case_insensitive, dot_all)) {
+      return false;
+    }
+    t++;
+    count++;
+  }
+
+  return false;
+}
+
+// Greedy range quantifier (e.g., {min,max})
+bool match_range(char c, const char *regex, const char *text, int min, int max,
+                 bool case_insensitive, bool dot_all, bool multi_line) {
+  const char *t = text;
+  int count = 0;
+
+  while (count < max && *t != '\0' && matches(c, *t, case_insensitive, dot_all)) {
+    t++;
+    count++;
+  }
+
+  while (count >= min) {
+    if (match_here(regex, t, case_insensitive, dot_all, multi_line)) {
+      return true;
+    }
+    t--;
+    count--;
+  }
+
+  return false;
+}
+
+// Range with no upper bound (e.g., {min,})
+bool match_range_infinite(char c, const char *regex, const char *text, int min,
+                          bool case_insensitive, bool dot_all,
+                          bool multi_line) {
+  const char *t = text;
+  int count = 0;
+
+  while (*t != '\0' && matches(c, *t, case_insensitive, dot_all)) {
+    t++;
+    count++;
+  }
+
+  if (count < min) {
     return false;
   }
-  return true;
+
+  do {
+    if (match_here(regex, t, case_insensitive, dot_all, multi_line)) {
+      return true;
+    }
+  } while (t-- > text + min);
+
+  return false;
 }
+

--- a/src/unicode.c
+++ b/src/unicode.c
@@ -6,7 +6,10 @@
 #include <ctype.h>
 #include "utils.h"
 
-void unicode_casefold(char c, char *out);
+static void unicode_casefold(char c, char *out) {
+  out[0] = (char)tolower((unsigned char)c);
+  out[1] = '\0';
+}
 
 
 bool match_unicode_property(char property, char c, bool negate) {
@@ -41,7 +44,7 @@ bool match_unicode_casefold(const char *regex, const char *text,
   if (case_insensitive) {
     char folded_char[4]; // Buffer to hold case-folded character
     unicode_casefold(*regex, folded_char); // Assume unicode_casefold function
-    return char_equals(folded_char, text, true);
+    return char_equals(folded_char[0], *text, true);
   }
   return char_equals(*regex, *text, case_insensitive);
 }


### PR DESCRIPTION
## Summary
- Rework quantifier helpers to operate on single characters and add lazy/possessive variants
- Align group and lookaround utilities with shared capture buffers
- Move capture buffers out of the header and provide a Unicode case-fold helper
- Exclude unused sources from the build system

## Testing
- `make test` *(fails: possessive quantifier mismatch and character class set operation cases)*

------
https://chatgpt.com/codex/tasks/task_e_6893c3c0047c8328b37c317adcc68525